### PR TITLE
古いブラウザ用CSSプロパティの削除

### DIFF
--- a/src/overlaySlide.css
+++ b/src/overlaySlide.css
@@ -17,13 +17,11 @@
   height: 100%;
   overflow: hidden;
   -webkit-transform: translate(-100vw, 0);
-      -ms-transform: translate(-100vw, 0);
           transform: translate(-100vw, 0);
 }
 
 .olslide_item--prev {
   -webkit-transform: translate(-100vw, 0);
-      -ms-transform: translate(-100vw, 0);
           transform: translate(-100vw, 0);
   -webkit-animation-name: update-prev;
           animation-name: update-prev;
@@ -60,7 +58,6 @@
 .olslide_item--current {
   /* position: relative; */
   -webkit-transform: translate(-10vw, 0);
-      -ms-transform: translate(-10vw, 0);
           transform: translate(-10vw, 0);
   -webkit-animation-name: update-current;
           animation-name: update-current;
@@ -74,7 +71,6 @@
 
 .olslide_item--current::after {
   -webkit-transition: all 1s cubic-bezier(0.77, 0, 0.175, 1);
-  -o-transition: all 1s cubic-bezier(0.77, 0, 0.175, 1);
   transition: all 1s cubic-bezier(0.77, 0, 0.175, 1);
   position: absolute;
   top: 0;
@@ -113,7 +109,6 @@
   position: relative;
   z-index: 2;
   -webkit-transform: translate(90vw, 0);
-      -ms-transform: translate(90vw, 0);
           transform: translate(90vw, 0);
   -webkit-animation-name: update-next;
           animation-name: update-next;
@@ -162,13 +157,11 @@
   display: block;
   width: 100%;
   height: 100%;
-  -o-object-fit: cover;
-     object-fit: cover;
+  object-fit: cover;
   position: absolute;
   top: 50%;
   left: 50%;
   -webkit-transform: translate(-50%, -50%);
-      -ms-transform: translate(-50%, -50%);
           transform: translate(-50%, -50%);
   margin-left: auto;
   margin-right: auto;


### PR DESCRIPTION
Remove old properties for IE9, Opera 10-18,  Opera Mobile 11.5-23 from stylesheet

CSS old properties:
    -ms-transform: IE9
    -o-transform: Opera 10.5-15
    -o-transition: Opera 10.1-15, Opera Mobile 10.1-15
    -o-object-fit: Opera 11.6-18, Opera Mobile 11.5-23